### PR TITLE
Add support for maven.repo.local

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinder.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinder.java
@@ -32,6 +32,11 @@ class DirectoryFinder
 
     public static File getMavenRepsitoryDir(String userSettings, String globalSettings)
     {
+        if (System.getProperty("maven.repo.local") != null) 
+        {
+            return new File(System.getProperty("maven.repo.local"));
+    	}
+ 
         File mavenConfFile = new File(System.getProperty("user.home"), ".m2/settings.xml");
         if (userSettings != null)
         {

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -99,6 +99,10 @@ public class MavenDependencyScanner implements Scanner
         properties.setProperty("outputFile", tempFile.toAbsolutePath().toString());
         properties.setProperty("outputAbsoluteArtifactFilename", "true");
         properties.setProperty("includeScope", "runtime"); // only runtime (scope compile + runtime)
+		if (System.getProperty("maven.repo.local") != null) 
+		{
+        	properties.setProperty("maven.repo.local", System.getProperty("maven.repo.local"));
+        }
         request.setProperties(properties);
 
         Invoker invoker = new DefaultInvoker();


### PR DESCRIPTION
When using the licensecheck sensor in a maven build (maven sonar:sonar) it does not work if the local repository is specified using the "-Dmaven.repo.local=...." option.

This patch adds support for this.