### PR TITLE
Optionally resolve transitive NPM dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The plugin scans for dependencies defined in your project including all transiti
 Currently supported formats are:
 * Maven POM files - all dependencies with scope "compile" and "runtime" are checked
 * NPM package.json files - all dependencies (except "devDependencies") are checked
+** Note that transitive dependencies are _not_ scanned unless `licensecheck.npm.resolvetransitive` is set to `true`.
 
 ### Project Dashboard
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The plugin scans for dependencies defined in your project including all transiti
 Currently supported formats are:
 * Maven POM files - all dependencies with scope "compile" and "runtime" are checked
 * NPM package.json files - all dependencies (except "devDependencies") are checked
-** Note that transitive dependencies are _not_ scanned unless `licensecheck.npm.resolvetransitive` is set to `true`.
+  * Note that transitive dependencies are _not_ scanned unless `licensecheck.npm.resolvetransitive` is set to `true`.
 
 ### Project Dashboard
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPropertyKeys.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPropertyKeys.java
@@ -9,4 +9,6 @@ public class LicenseCheckPropertyKeys
     public static final String ALLOWED_DEPENDENCIES_KEY = "licensecheck.alloweddependencies";
 
     public static final String PROJECT_LICENSE_KEY = "licensecheck.projectlicense";
+
+    public static final String NPM_RESOLVE_TRANSITVE_DEPS = "licensecheck.npm.resolvetransitive";
 }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
@@ -44,7 +44,7 @@ public class LicenseCheckSensor implements Sensor
         this.settings = settings;
         this.validateLicenses = validateLicenses;
         this.scanners = new Scanner[]{
-            new PackageJsonDependencyScanner(),
+            new PackageJsonDependencyScanner(settings),
             new MavenDependencyScanner(mavenLicenseService, mavenDependencyService)};
     }
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
@@ -2,7 +2,6 @@ package at.porscheinformatik.sonarqube.licensecheck;
 
 import static java.util.Collections.newSetFromMap;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +43,7 @@ public class LicenseCheckSensor implements Sensor
         this.settings = settings;
         this.validateLicenses = validateLicenses;
         this.scanners = new Scanner[]{
-            new PackageJsonDependencyScanner(settings),
+            new PackageJsonDependencyScanner(settings.getBoolean(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS)),
             new MavenDependencyScanner(mavenLicenseService, mavenDependencyService)};
     }
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -85,15 +85,15 @@ public class ValidateLicenses
             {
                 String notAllowedLicense = "";
 
-                for(License element : licensesContainingDependency) {
-                    if(element.getStatus() == "false") {
+                for (License element : licensesContainingDependency) {
+                    if (element.getStatus() == "false") {
                         notAllowedLicense += element.getName() + " ";
                     }
                 }
                 licenseNotAllowedIssue(context, dependency, notAllowedLicense);
             }
         }
-    }    
+    }
 
     private boolean checkSpdxLicense(String spdxLicenseString, List<License> licenses)
     {
@@ -115,7 +115,7 @@ public class ValidateLicenses
             .isPresent();
     }
 
-    private boolean checkSpdxLicenseWithOr(String spdxLicenseString, List<License> licenses){
+    private boolean checkSpdxLicenseWithOr(String spdxLicenseString, List<License> licenses) {
         String[] orLicenses = spdxLicenseString.replace("(", "").replace(")", "").split(" OR ");
         return licenses
             .stream()
@@ -138,7 +138,7 @@ public class ValidateLicenses
         {
             return true;
         }
-        else if(foundLicenses.size() == count)
+        else if (foundLicenses.size() == count)
         {
             // NOT ALLOWED
             return false;
@@ -177,7 +177,7 @@ public class ValidateLicenses
         issue.save();
     }
 
-    private static boolean contains(String[] items, String valueToFind) 
+    private static boolean contains(String[] items, String valueToFind)
     {
         for (String item : items)
         {

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/interfaces/Scanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/interfaces/Scanner.java
@@ -1,11 +1,11 @@
 package at.porscheinformatik.sonarqube.licensecheck.interfaces;
 
 import java.io.File;
-import java.util.List;
+import java.util.Set;
 
 import at.porscheinformatik.sonarqube.licensecheck.Dependency;
 
 public interface Scanner
 {
-    List<Dependency> scan(File moduleDir);
+    Set<Dependency> scan(File moduleDir);
 }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -60,8 +60,11 @@ public class MavenDependencyScanner implements Scanner
     {
         if (!new File(moduleDir, "pom.xml").exists())
         {
+            LOGGER.info("No pom.xml file found in {} - skipping Maven dependency scan", moduleDir.getPath());
             return Collections.emptySet();
         }
+
+        LOGGER.info("Scanning for Maven dependencies");
 
         String userSettings = null;
         String globalSettings = null;

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -58,7 +58,7 @@ public class MavenDependencyScanner implements Scanner
     @Override
     public Set<Dependency> scan(File moduleDir)
     {
-        if(!new File(moduleDir, "pom.xml").exists())
+        if (!new File(moduleDir, "pom.xml").exists())
         {
             return Collections.emptySet();
         }
@@ -78,13 +78,13 @@ public class MavenDependencyScanner implements Scanner
             }
         }
 
-        return this.readDependecyList(moduleDir, userSettings, globalSettings)
+        return this.readDependencyList(moduleDir, userSettings, globalSettings)
             .map(this.loadLicenseFromPom(mavenLicenseService.getLicenseMap(), userSettings, globalSettings))
             .map(this::mapMavenDependencyToLicense)
             .collect(Collectors.toSet());
     }
 
-    private Stream<Dependency> readDependecyList(File moduleDir, String userSettings, String globalSettings)
+    private Stream<Dependency> readDependencyList(File moduleDir, String userSettings, String globalSettings)
     {
         Path tempFile = createTempFile();
         if (tempFile == null)

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,11 +56,11 @@ public class MavenDependencyScanner implements Scanner
     }
 
     @Override
-    public List<Dependency> scan(File moduleDir)
+    public Set<Dependency> scan(File moduleDir)
     {
         if(!new File(moduleDir, "pom.xml").exists())
         {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
 
         String userSettings = null;
@@ -80,7 +81,7 @@ public class MavenDependencyScanner implements Scanner
         return this.readDependecyList(moduleDir, userSettings, globalSettings)
             .map(this.loadLicenseFromPom(mavenLicenseService.getLicenseMap(), userSettings, globalSettings))
             .map(this::mapMavenDependencyToLicense)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
 
     private Stream<Dependency> readDependecyList(File moduleDir, String userSettings, String globalSettings)

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
@@ -41,8 +41,11 @@ public class PackageJsonDependencyScanner implements Scanner
 
         if (!packageJsonFile.exists())
         {
+            LOGGER.info("No package.json file found in {} - skipping NPM dependency scan", moduleDir.getPath());
             return Collections.emptySet();
         }
+
+        LOGGER.info("Scanning for NPM dependencies");
 
         File nodeModulesFolder = new File(packageJsonFile.getParentFile(), "node_modules");
         if (!nodeModulesFolder.exists() || !nodeModulesFolder.isDirectory())

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
@@ -78,7 +78,7 @@ public class PackageJsonDependencyScanner implements Scanner
         {
             if (dependencies.stream().anyMatch(d -> packageName.equals(d.getName())))
             {
-                LOGGER.warn("Circular dependency detected in {}. Current dependencies: {}", packageName, dependencies);
+                LOGGER.debug("Package {} has already been encountered and will not be scanned again", packageName);
                 continue;
             }
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
@@ -35,9 +35,9 @@ public class PackageJsonDependencyScanner implements Scanner
     }
 
     @Override
-    public Set<Dependency> scan(File file)
+    public Set<Dependency> scan(File moduleDir)
     {
-        File packageJsonFile = new File(file, "package.json");
+        File packageJsonFile = new File(moduleDir, "package.json");
 
         if (!packageJsonFile.exists())
         {

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
@@ -5,12 +5,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.json.Json;
@@ -43,25 +39,26 @@ public class PackageJsonDependencyScanner implements Scanner
     {
         File packageJsonFile = new File(file, "package.json");
 
-        if (packageJsonFile.exists())
+        if (!packageJsonFile.exists())
         {
-            File nodeModulesFolder = new File(packageJsonFile.getParentFile(), "node_modules");
-            if (!nodeModulesFolder.exists() || !nodeModulesFolder.isDirectory())
-            {
-                return Collections.emptySet();
-            }
-
-            try (InputStream fis = new FileInputStream(packageJsonFile); JsonReader jsonReader = Json.createReader(fis))
-            {
-                Deque<String> transitiveStack = new ArrayDeque<>();
-                return getDependenciesFrom(jsonReader.readObject(), nodeModulesFolder);
-            }
-            catch (IOException e)
-            {
-                LOGGER.error("Error reading package.json", e);
-            }
+            return Collections.emptySet();
         }
-        return Collections.emptySet();
+
+        File nodeModulesFolder = new File(packageJsonFile.getParentFile(), "node_modules");
+        if (!nodeModulesFolder.exists() || !nodeModulesFolder.isDirectory())
+        {
+            return Collections.emptySet();
+        }
+
+        try (InputStream fis = new FileInputStream(packageJsonFile); JsonReader jsonReader = Json.createReader(fis))
+        {
+            return getDependenciesFrom(jsonReader.readObject(), nodeModulesFolder);
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("Error reading package.json", e);
+            return Collections.emptySet();
+        }
     }
 
     private Set<Dependency> getDependenciesFrom(JsonObject packageJsonObject, File nodeModulesFolder)

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import at.porscheinformatik.sonarqube.licensecheck.interfaces.Scanner;
@@ -14,6 +12,8 @@ import org.sonar.api.config.Settings;
 import org.sonar.api.config.internal.MapSettings;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
 public class PackageJsonDependencyScannerTest
 {
@@ -22,30 +22,31 @@ public class PackageJsonDependencyScannerTest
     @Test
     public void testHappyPath()
     {
-        Scanner scanner = new PackageJsonDependencyScanner();
+        Scanner scanner = new PackageJsonDependencyScanner(new MapSettings());
 
         List<Dependency> dependencies = scanner.scan(folder);
 
-        Assert.assertThat(dependencies, contains(
+        assertThat(dependencies, hasSize(2));
+        assertThat(dependencies, contains(
             new Dependency("angular", "1.5.0", "MIT"),
             new Dependency("arangojs", "5.6.0", "Apache-2.0")));
     }
 
-    @Ignore
     @Test
     public void testTransitive()
     {
         Settings settings = new MapSettings();
         settings.addProperties(Collections.singletonMap(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS, "true"));
 
-        Scanner scanner = new PackageJsonDependencyScanner();
+        Scanner scanner = new PackageJsonDependencyScanner(settings);
 
         List<Dependency> dependencies = scanner.scan(folder);
 
-        Assert.assertThat(dependencies, contains(
+        assertThat(dependencies, hasSize(4));
+        assertThat(dependencies, contains(
             new Dependency("angular", "1.5.0", "MIT"),
             new Dependency("arangojs", "5.6.0", "Apache-2.0"),
-            new Dependency("linkedlist", "5.6.0", "Apache-2.0"),
-            new Dependency("retry", "5.6.0", "Apache-2.0")));
+            new Dependency("linkedlist", "1.0.1", "LGPLv3"),
+            new Dependency("retry", "0.10.1", "MIT")));
     }
 }

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
@@ -1,17 +1,14 @@
 package at.porscheinformatik.sonarqube.licensecheck;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Set;
 
 import org.junit.Test;
 
 import at.porscheinformatik.sonarqube.licensecheck.interfaces.Scanner;
 import at.porscheinformatik.sonarqube.licensecheck.npm.PackageJsonDependencyScanner;
-import org.sonar.api.config.Settings;
-import org.sonar.api.config.internal.MapSettings;
 
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
@@ -22,12 +19,12 @@ public class PackageJsonDependencyScannerTest
     @Test
     public void testHappyPath()
     {
-        Scanner scanner = new PackageJsonDependencyScanner(new MapSettings());
+        Scanner scanner = new PackageJsonDependencyScanner(false);
 
         Set<Dependency> dependencies = scanner.scan(folder);
 
         assertThat(dependencies, hasSize(2));
-        assertThat(dependencies, contains(
+        assertThat(dependencies, containsInAnyOrder(
             new Dependency("angular", "1.5.0", "MIT"),
             new Dependency("arangojs", "5.6.0", "Apache-2.0")));
     }
@@ -35,18 +32,35 @@ public class PackageJsonDependencyScannerTest
     @Test
     public void testTransitive()
     {
-        Settings settings = new MapSettings();
-        settings.addProperties(Collections.singletonMap(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS, "true"));
-
-        Scanner scanner = new PackageJsonDependencyScanner(settings);
+        Scanner scanner = new PackageJsonDependencyScanner(true);
 
         Set<Dependency> dependencies = scanner.scan(folder);
 
         assertThat(dependencies, hasSize(4));
-        assertThat(dependencies, contains(
+        assertThat(dependencies, containsInAnyOrder(
             new Dependency("angular", "1.5.0", "MIT"),
             new Dependency("arangojs", "5.6.0", "Apache-2.0"),
             new Dependency("linkedlist", "1.0.1", "LGPLv3"),
             new Dependency("retry", "0.10.1", "MIT")));
+    }
+
+    @Test
+    public void testNoPackageJson()
+    {
+        Scanner scanner = new PackageJsonDependencyScanner(false);
+
+        Set<Dependency> dependencies = scanner.scan(new File("src"));
+
+        assertThat(dependencies, hasSize(0));
+    }
+
+    @Test
+    public void testNoNodeModules()
+    {
+        Scanner scanner = new PackageJsonDependencyScanner(false);
+
+        Set<Dependency> dependencies = scanner.scan(new File(folder, "node_modules/arangojs"));
+
+        assertThat(dependencies, hasSize(0));
     }
 }

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertThat;
 
 public class PackageJsonDependencyScannerTest
 {
-    final File folder = new File("src/test/resources");
+    private final File folder = new File("src/test/resources");
 
     @Test
     public void testHappyPath()

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
@@ -2,7 +2,7 @@ package at.porscheinformatik.sonarqube.licensecheck;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -24,7 +24,7 @@ public class PackageJsonDependencyScannerTest
     {
         Scanner scanner = new PackageJsonDependencyScanner(new MapSettings());
 
-        List<Dependency> dependencies = scanner.scan(folder);
+        Set<Dependency> dependencies = scanner.scan(folder);
 
         assertThat(dependencies, hasSize(2));
         assertThat(dependencies, contains(
@@ -40,7 +40,7 @@ public class PackageJsonDependencyScannerTest
 
         Scanner scanner = new PackageJsonDependencyScanner(settings);
 
-        List<Dependency> dependencies = scanner.scan(folder);
+        Set<Dependency> dependencies = scanner.scan(folder);
 
         assertThat(dependencies, hasSize(4));
         assertThat(dependencies, contains(

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/PackageJsonDependencyScannerTest.java
@@ -1,14 +1,19 @@
 package at.porscheinformatik.sonarqube.licensecheck;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import at.porscheinformatik.sonarqube.licensecheck.interfaces.Scanner;
 import at.porscheinformatik.sonarqube.licensecheck.npm.PackageJsonDependencyScanner;
+import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
+
+import static org.hamcrest.Matchers.contains;
 
 public class PackageJsonDependencyScannerTest
 {
@@ -21,6 +26,26 @@ public class PackageJsonDependencyScannerTest
 
         List<Dependency> dependencies = scanner.scan(folder);
 
-        Assert.assertThat(dependencies, CoreMatchers.hasItem(new Dependency("angular", "1.5.0", "MIT")));
+        Assert.assertThat(dependencies, contains(
+            new Dependency("angular", "1.5.0", "MIT"),
+            new Dependency("arangojs", "5.6.0", "Apache-2.0")));
+    }
+
+    @Ignore
+    @Test
+    public void testTransitive()
+    {
+        Settings settings = new MapSettings();
+        settings.addProperties(Collections.singletonMap(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS, "true"));
+
+        Scanner scanner = new PackageJsonDependencyScanner();
+
+        List<Dependency> dependencies = scanner.scan(folder);
+
+        Assert.assertThat(dependencies, contains(
+            new Dependency("angular", "1.5.0", "MIT"),
+            new Dependency("arangojs", "5.6.0", "Apache-2.0"),
+            new Dependency("linkedlist", "5.6.0", "Apache-2.0"),
+            new Dependency("retry", "5.6.0", "Apache-2.0")));
     }
 }

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScannerTest.java
@@ -9,8 +9,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.hamcrest.Matchers;
@@ -39,7 +39,7 @@ public class MavenDependencyScannerTest
         Scanner scanner = new MavenDependencyScanner(licenseService, dependencyService);
 
         // -
-        List<Dependency> dependencies = scanner.scan(moduleDir);
+        Set<Dependency> dependencies = scanner.scan(moduleDir);
 
         assertThat(dependencies.size(), Matchers.greaterThan(0));
 
@@ -66,7 +66,7 @@ public class MavenDependencyScannerTest
 
         File moduleDir = Files.createTempDirectory("lala").toFile();
         moduleDir.deleteOnExit();
-        List<Dependency> dependencies = scanner.scan(moduleDir);
+        Set<Dependency> dependencies = scanner.scan(moduleDir);
 
         assertThat(dependencies.size(), is(0));
     }

--- a/src/test/resources/node_modules/arangojs/package.json
+++ b/src/test/resources/node_modules/arangojs/package.json
@@ -1,0 +1,88 @@
+{
+  "name": "arangojs",
+  "version": "5.6.0",
+  "license": "Apache-2.0",
+  "description": "The official ArangoDB JavaScript driver.",
+  "homepage": "https://github.com/arangodb/arangojs",
+  "author": "ArangoDB GmbH",
+  "keywords": [
+    "arango",
+    "arangodb",
+    "aql",
+    "nosql",
+    "client",
+    "driver",
+    "api",
+    "http",
+    "rest"
+  ],
+  "main": "lib/index.js",
+  "browser": {
+    "./lib/util/btoa.js": "./lib/util/btoa.web.js",
+    "./lib/util/bytelength.js": "./lib/util/bytelength.web.js",
+    "./lib/util/multipart.js": "./lib/util/multipart.web.js",
+    "./lib/util/request.js": "./lib/util/request.web.js"
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib/",
+    "package.json",
+    "arangojs.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "typings": "arangojs.d.ts",
+  "scripts": {
+    "test": "mocha --growl",
+    "lint": "snazzy --verbose src/**/*.js test/**/*.js",
+    "ci": "mocha",
+    "watch": "npm-run-all -p watch:*",
+    "watch:browser": "npm run dist:browser -- --watch",
+    "watch:node": "watch 'npm run dist:node' ./src ./test",
+    "watch:test": "watch 'npm run lint && npm run test' ./src ./test",
+    "dist": "npm-run-all -p dist:*",
+    "dist:browser": "webpack",
+    "dist:node": "babel --compact false -d lib src",
+    "prepublish": "npm run lint && npm run dist && node -e 'require(\"./\");'"
+  },
+  "dependencies": {
+    "linkedlist": "^1.0.1",
+    "retry": "^0.10.0"
+  },
+  "devDependencies": {
+    "babel-cli": "6.22.2",
+    "babel-core": "6.22.1",
+    "babel-loader": "6.2.9",
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-transform-builtin-extend": "1.1.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.22.0",
+    "babel-preset-es2015": "6.22.0",
+    "babel-preset-stage-1": "6.22.0",
+    "chai": "3.5.0",
+    "core-js": "2.4.1",
+    "coveralls": "2.11.15",
+    "istanbul": "0.4.5",
+    "json-loader": "0.5.4",
+    "mocha": "3.2.0",
+    "npm-run-all": "4.0.1",
+    "snazzy": "6.0.0",
+    "standard": "8.6.0",
+    "watch": "1.0.1",
+    "webpack": "1.14.0"
+  },
+  "contributors": [
+    {
+      "name": "Alan Plum",
+      "email": "me@pluma.io"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/arangodb/arangojs/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/arangodb/arangojs.git"
+  }
+}

--- a/src/test/resources/node_modules/linkedlist/package.json
+++ b/src/test/resources/node_modules/linkedlist/package.json
@@ -1,0 +1,23 @@
+{
+  "author": "Kilian Ciuffolo <me@nailik.org> (http://nailik.org)",
+  "name": "linkedlist",
+  "description": "Array like linked list with iterator",
+  "keywords": ["array", "linked", "list", "linkedlist", "iterator"],
+  "version": "1.0.1",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/kilianc/node-linkedlist.git"
+  },
+  "main" : "./",
+  "scripts": {
+    "test": "make test"
+  },
+  "engines": {
+    "node": ">= v0.6.x"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "mocha": "1.0.x",
+    "should": "0.6.1"
+  }
+}

--- a/src/test/resources/node_modules/linkedlist/package.json
+++ b/src/test/resources/node_modules/linkedlist/package.json
@@ -18,7 +18,9 @@
   "engines": {
     "node": ">= v0.6.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "retry": "^1.2.3"
+  },
   "devDependencies": {
     "mocha": "1.0.x",
     "should": "0.6.1"

--- a/src/test/resources/node_modules/linkedlist/package.json
+++ b/src/test/resources/node_modules/linkedlist/package.json
@@ -1,6 +1,9 @@
 {
   "author": "Kilian Ciuffolo <me@nailik.org> (http://nailik.org)",
   "name": "linkedlist",
+  "licenses": [{
+    "type": "LGPLv3"
+  }],
   "description": "Array like linked list with iterator",
   "keywords": ["array", "linked", "list", "linkedlist", "iterator"],
   "version": "1.0.1",

--- a/src/test/resources/node_modules/retry/package.json
+++ b/src/test/resources/node_modules/retry/package.json
@@ -1,0 +1,26 @@
+{
+  "author": "Tim Koschützki <tim@debuggable.com> (http://debuggable.com/)",
+  "name": "retry",
+  "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+  "license": "MIT",
+  "version": "0.10.1",
+  "homepage": "https://github.com/tim-kos/node-retry",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tim-kos/node-retry.git"
+  },
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "index",
+  "engines": {
+    "node": "*"
+  },
+  "dependencies": {
+    "linkedlist": "^1.0.1"
+  },
+  "devDependencies": {
+    "fake": "0.2.0",
+    "far": "0.0.1"
+  }
+}

--- a/src/test/resources/package.json
+++ b/src/test/resources/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "angular": "^1.4.3",
     "angular-ui-router" : "~0.2.18",
-    "angular-ui-bootstrap" : "1.1.2"
+    "angular-ui-bootstrap" : "1.1.2",
+    "arangojs" : "5.6.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1"


### PR DESCRIPTION
Closes #21.

Probably has merge conflicts with #73.  I'll happily fix up conflicts on either PR after the first one is merged (assuming that happens!)

This PR performs the logic using recursion, and makes use of a `Set` to ensure we don't record duplicates where the same dependency is transitively pulled in more than once.  UTs are included to prove the behaviour.

**Update:** after running a local build of this we encountered a StackOverflowException when circular dependencies existed.  I've now made use of a `Deque` to track and warn on such instances so we don't fall down the rabbit hole.