### PR TITLE
Fix could not handle unknown maven arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,20 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -106,7 +112,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
+      <version>3.6.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
@@ -168,13 +179,19 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.4</version>
         <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-        </executions>
+      <execution>
+        <id>prepare-agent</id>
+        <goals>
+         <goal>prepare-agent</goal>
+        </goals>
+      </execution>
+      <execution>
+        <id>report</id>
+        <goals>
+         <goal>report</goal>
+        </goals>
+      </execution>
+    </executions>
       </plugin>
       <plugin>
         <groupId>com.github.eirslett</groupId>

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -12,14 +12,12 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -38,6 +36,7 @@ import at.porscheinformatik.sonarqube.licensecheck.interfaces.Scanner;
 import at.porscheinformatik.sonarqube.licensecheck.mavendependency.MavenDependency;
 import at.porscheinformatik.sonarqube.licensecheck.mavendependency.MavenDependencyService;
 import at.porscheinformatik.sonarqube.licensecheck.mavenlicense.MavenLicenseService;
+import at.porscheinformatik.sonarqube.licensecheck.utils.ExtendedParser;
 
 public class MavenDependencyScanner implements Scanner
 {
@@ -73,11 +72,17 @@ public class MavenDependencyScanner implements Scanner
             if (cmd.hasOption("s"))
             {
                 userSettings = cmd.getOptionValue("s");
+                LOGGER.debug("-s {}",userSettings);
             }
             if (cmd.hasOption("gs"))
             {
                 globalSettings = cmd.getOptionValue("gs");
+                LOGGER.debug("-gs {}", globalSettings);
             }
+        }
+        else
+        {
+        	LOGGER.debug("no cli");
         }
 
         return readDependencyList(moduleDir, userSettings, globalSettings)
@@ -282,7 +287,7 @@ public class MavenDependencyScanner implements Scanner
             }
         }
 
-        LOGGER.info("No licenses found for '{}'", licenseName);
+        LOGGER.warn("No licenses found for '{}'", licenseName);
     }
 
     private Dependency mapMavenDependencyToLicense(Dependency dependency)
@@ -309,15 +314,15 @@ public class MavenDependencyScanner implements Scanner
         try
         {
             String commandArgs = System.getProperty("sun.java.command");
-            CommandLineParser parser = new DefaultParser();
+            CommandLineParser parser = new ExtendedParser();
             Options options = new Options();
             options.addOption("s", "settings", true, "Alternate path for the user settings file");
             options.addOption("gs", "global-settings", true, "Alternate path for the global settings file");
-            cmd = parser.parse(options, commandArgs.split(" "));
+            cmd = parser.parse(options, commandArgs.split(" "), false);
         }
         catch (Exception e)
         {
-            // ignore unparsable command line args
+            LOGGER.warn(e.toString());
         }
         return cmd;
     }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/utils/ExtendedParser.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/utils/ExtendedParser.java
@@ -1,0 +1,43 @@
+package at.porscheinformatik.sonarqube.licensecheck.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+/**
+ * This class is taken from stackoverflow
+ * https://stackoverflow.com/a/53296095/12066835
+ * the author there is SimoV8
+ */
+public class ExtendedParser extends DefaultParser {
+
+	private final ArrayList<String> notParsedArgs = new ArrayList<>();
+
+	public String[] getNotParsedArgs() {
+		return notParsedArgs.toArray(new String[notParsedArgs.size()]);
+	}
+
+	@Override
+	public CommandLine parse(Options options, String[] arguments, boolean stopAtNonOption) throws ParseException {
+		if (stopAtNonOption) {
+			return parse(options, arguments);
+		}
+		List<String> knownArguments = new ArrayList<>();
+		notParsedArgs.clear();
+		boolean nextArgument = false;
+		for (String arg : arguments) {
+			if (options.hasOption(arg) || nextArgument) {
+				knownArguments.add(arg);
+			} else {
+				notParsedArgs.add(arg);
+			}
+
+			nextArgument = options.hasOption(arg) && options.getOption(arg).hasArg();
+		}
+		return super.parse(options, knownArguments.toArray(new String[knownArguments.size()]));
+	}
+
+}

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScannerTest.java
@@ -16,7 +16,10 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.mockito.Mockito;
 
 import at.porscheinformatik.sonarqube.licensecheck.Dependency;
@@ -110,6 +113,23 @@ public class MavenDependencyScannerTest
         assertThat(dependency.getPomPath(), endsWith("test.pom"));
     }
 
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+    @Rule
+	public final ProvideSystemProperty myPropertyHasMyValue	 = new ProvideSystemProperty("sun.java.command", "-X -s src/test/resources/settings.xml -gs src/test/resources/settings.xml -B");
+    @Test
+    public void testMavenSettings()
+    {
+        String jarFilePath = new File("src/test/resources/test-sources.jar").getAbsolutePath();
+        Dependency dependency = MavenDependencyScanner.findDependency(
+            "at.porscheinformatik.test:test:jar:sources:2.2:compile:" + jarFilePath + " -- module test (auto)");
+
+        assertThat(dependency.getName(), is("at.porscheinformatik.test:test"));
+        assertThat(dependency.getVersion(), is("2.2"));
+        assertThat(dependency.getPomPath(), endsWith("test.pom"));
+    }
+    
+    
     @Test
     public void testFindDependencyWithClassifier()
     {

--- a/src/test/resources/settings.xml
+++ b/src/test/resources/settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  
+  <mirrors>
+    <mirror>
+      <id>UK</id>
+      <name>UK Central</name>
+      <url>http://uk.maven.org/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+  
+</settings>


### PR DESCRIPTION
Until this patch you could only use parameters -s and -gs. All other broke the internal maven call.

