### PR TITLE
Fix Maven settings parameter propagation, closes #90

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node/
 package.json
 .idea/
 *.iml
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -48,19 +48,20 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.27</version>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
       <version>1.1.4</version>
     </dependency>
     <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <version>1.4</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.27</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.27</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -12,15 +12,10 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.License;
@@ -65,28 +60,15 @@ public class MavenDependencyScanner implements Scanner
 
         LOGGER.info("Scanning for Maven dependencies");
 
-        String userSettings = null;
-        String globalSettings = null;
-        CommandLine cmd = getCommandLineArgs();
-        if (cmd != null)
-        {
-            if (cmd.hasOption("s"))
-            {
-                userSettings = cmd.getOptionValue("s");
-            }
-            if (cmd.hasOption("gs"))
-            {
-                globalSettings = cmd.getOptionValue("gs");
-            }
-        }
+        MavenSettings settings = getSettingsFromCommandLineArgs();
 
-        return readDependencyList(moduleDir, userSettings, globalSettings)
+        return readDependencyList(moduleDir, settings)
             .map(this::mapMavenDependencyToLicense)
-            .map(this.loadLicenseFromPom(mavenLicenseService.getLicenseMap(), userSettings, globalSettings))
+            .map(this.loadLicenseFromPom(mavenLicenseService.getLicenseMap(), settings))
             .collect(Collectors.toSet());
     }
 
-    private static Stream<Dependency> readDependencyList(File moduleDir, String userSettings, String globalSettings)
+    private static Stream<Dependency> readDependencyList(File moduleDir, MavenSettings settings)
     {
         Path tempFile = createTempFile();
         if (tempFile == null)
@@ -98,13 +80,15 @@ public class MavenDependencyScanner implements Scanner
         request.setRecursive(false);
         request.setPomFile(new File(moduleDir, "pom.xml"));
         request.setGoals(Collections.singletonList("dependency:list"));
-        if (userSettings != null)
+        if (settings.userSettings != null)
         {
-            request.setUserSettingsFile(new File(userSettings));
+            request.setUserSettingsFile(new File(settings.userSettings));
+            LOGGER.info("Using user settings {}", settings.userSettings);
         }
-        if (globalSettings != null)
+        if (settings.globalSettings != null)
         {
-            request.setGlobalSettingsFile(new File(globalSettings));
+            request.setGlobalSettingsFile(new File(settings.globalSettings));
+            LOGGER.info("Using global settings {}", settings.userSettings);
         }
         Properties properties = new Properties();
         properties.setProperty("outputFile", tempFile.toAbsolutePath().toString());
@@ -228,8 +212,7 @@ public class MavenDependencyScanner implements Scanner
         return items;
     }
 
-    private Function<Dependency, Dependency> loadLicenseFromPom(Map<Pattern, String> licenseMap, String userSettings,
-        String globalSettings)
+    private Function<Dependency, Dependency> loadLicenseFromPom(Map<Pattern, String> licenseMap, MavenSettings settings)
     {
         return (Dependency dependency) ->
         {
@@ -239,17 +222,17 @@ public class MavenDependencyScanner implements Scanner
                 return dependency;
             }
 
-            return loadLicense(licenseMap, userSettings, globalSettings, dependency);
+            return loadLicense(licenseMap, settings, dependency);
         };
     }
 
-    private static Dependency loadLicense(Map<Pattern, String> licenseMap, String userSettings, String globalSettings,
-        Dependency dependency)
+    private static Dependency loadLicense(Map<Pattern, String> licenseMap, MavenSettings settings, Dependency dependency)
     {
         String pomPath = dependency.getPomPath();
         if (pomPath != null)
         {
-            List<License> licenses = LicenseFinder.getLicenses(new File(pomPath), userSettings, globalSettings);
+            List<License> licenses = LicenseFinder.getLicenses(new File(pomPath), settings.userSettings, 
+                settings.globalSettings);
             if (licenses.isEmpty())
             {
                 LOGGER.info("No licenses found in dependency {}", dependency.getName());
@@ -303,22 +286,42 @@ public class MavenDependencyScanner implements Scanner
         return dependency;
     }
 
-    private static CommandLine getCommandLineArgs()
+    private static MavenSettings getSettingsFromCommandLineArgs()
     {
-        CommandLine cmd = null;
-        try
+        String globalSettings = null;
+        String userSettings = null;
+        String commandArgs = System.getProperty("sun.java.command");
+        try(java.util.Scanner scanner = new java.util.Scanner(commandArgs))
         {
-            String commandArgs = System.getProperty("sun.java.command");
-            CommandLineParser parser = new DefaultParser();
-            Options options = new Options();
-            options.addOption("s", "settings", true, "Alternate path for the user settings file");
-            options.addOption("gs", "global-settings", true, "Alternate path for the global settings file");
-            cmd = parser.parse(options, commandArgs.split(" "));
+            while (scanner.hasNext())
+            {
+                String part = scanner.next();
+                if (part.equals("-gs") || part.equals("--global-settings"))
+                {
+                    globalSettings = scanner.next();
+                }
+                else if (part.equals("-s") || part.equals("--settings"))
+                {
+                    userSettings = scanner.next();
+                }
+            }
         }
         catch (Exception e)
         {
-            // ignore unparsable command line args
+            LOGGER.debug("Ignore unparsable command line", e);
         }
-        return cmd;
+        return new MavenSettings(globalSettings, userSettings);
+    }
+}
+
+class MavenSettings
+{
+    final String globalSettings;
+    final String userSettings;
+
+    MavenSettings(String globalSettings, String userSetttings)
+    {
+        this.globalSettings = globalSettings;
+        this.userSettings = userSetttings;
     }
 }

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScannerTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScannerTest.java
@@ -121,4 +121,23 @@ public class MavenDependencyScannerTest
         assertThat(dependency.getVersion(), is("2.2"));
         assertThat(dependency.getPomPath(), endsWith("test.pom"));
     }
+
+    @Test
+    public void testSettingsFromMaven()
+    { 
+        String oldVal = System.getProperty("sun.java.command");
+        try
+        {
+            System.setProperty("sun.java.command", "thisisatest -X -s src/test/resources/settings-does-not-exist.xml -gs src/test/resources/settings-does-not-exist.xml -B");
+            Scanner scanner = new MavenDependencyScanner(mockLicenseService(), Mockito.mock(MavenDependencyService.class));
+            
+            Set<Dependency> dependencies = scanner.scan(new File("."));
+
+            assertThat(dependencies.size(), is(0));
+        }
+        finally
+        {
+            System.setProperty("sun.java.command", oldVal);
+        }
+    }
 }


### PR DESCRIPTION
commons-cli had problems parsing the command line (when the first parameter is not the settings one). Replaced the implementation with own implementation based on `java.util.Scanner`.