### PR TITLE
enable jacoco.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,9 +170,15 @@
         <version>0.8.4</version>
         <executions>
           <execution>
-            <id>default-prepare-agent</id>
+          <id>prepare-agent</id>
+          <goals>
+            <goal>prepare-agent</goal>
+          </goals>
+          </execution>
+          <execution>
+            <id>report</id>
             <goals>
-              <goal>prepare-agent</goal>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
enable jacoco.xml because jacoco.exec is deprecated in sonar