### PR TITLE
Enable setting of licensecheck.npm.resolvetransitive in the SonarQube UI

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPlugin.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPlugin.java
@@ -61,6 +61,9 @@ public class LicenseCheckPlugin implements Plugin
             PropertyDefinition.builder(LicenseCheckPropertyKeys.PROJECT_LICENSE_KEY)
                 .type(PropertyType.TEXT)
                 .build(),
+            PropertyDefinition.builder(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS)
+                .type(PropertyType.BOOLEAN)
+                .build(),
             PropertyDefinition.builder(LicenseCheckPropertyKeys.ACTIVATION_KEY)
                 .category("License Check")
                 .name("Activate")

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPlugin.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPlugin.java
@@ -61,7 +61,7 @@ public class LicenseCheckPlugin implements Plugin
             PropertyDefinition.builder(LicenseCheckPropertyKeys.PROJECT_LICENSE_KEY)
                 .type(PropertyType.TEXT)
                 .build(),
-            PropertyDefinition.builder(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS)
+            PropertyDefinition.builder(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITIVE_DEPS)
                 .type(PropertyType.BOOLEAN)
                 .build(),
             PropertyDefinition.builder(LicenseCheckPropertyKeys.ACTIVATION_KEY)

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPropertyKeys.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPropertyKeys.java
@@ -10,5 +10,5 @@ public class LicenseCheckPropertyKeys
 
     public static final String PROJECT_LICENSE_KEY = "licensecheck.projectlicense";
 
-    public static final String NPM_RESOLVE_TRANSITVE_DEPS = "licensecheck.npm.resolvetransitive";
+    public static final String NPM_RESOLVE_TRANSITIVE_DEPS = "licensecheck.npm.resolvetransitive";
 }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
@@ -41,7 +41,7 @@ public class LicenseCheckSensor implements Sensor
         this.validateLicenses = validateLicenses;
         this.scanners = new Scanner[]{
             new PackageJsonDependencyScanner(
-                configuration.getBoolean(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITVE_DEPS).orElse(false)),
+                configuration.getBoolean(LicenseCheckPropertyKeys.NPM_RESOLVE_TRANSITIVE_DEPS).orElse(false)),
             new MavenDependencyScanner(mavenLicenseService, mavenDependencyService)};
     }
 


### PR DESCRIPTION
I will be happy to add name and category to NPM_RESOLVE_TRANSITIVE_DEPS if you indicate some details.