### PR TITLE
Implemented custom and custom forced license mappings for badly maintained licenses

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPlugin.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPlugin.java
@@ -68,6 +68,17 @@ public class LicenseCheckPlugin implements Plugin
                 .description("Activate license check")
                 .type(PropertyType.BOOLEAN)
                 .defaultValue("true")
-                .build());
+                .build(),
+            PropertyDefinition.builder(LicenseCheckPropertyKeys.CUSTOM_LICENSE_MAPPINGS)
+                .category("License Check")
+                .name("Custom Mapping")
+                .description(
+                    "Explicitly specify licenses for dependencies where licenses can not be resolved automatically.")
+                .type(PropertyType.TEXT).build(),
+            PropertyDefinition.builder(LicenseCheckPropertyKeys.FORCED_LICENSE_MAPPINGS)
+                .category("License Check")
+                .name("Forced Mapping")
+                .description("Explicitly force licenses for dependencies where faulty license identifiers are found.")
+                .type(PropertyType.TEXT).build());
     }
 }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPropertyKeys.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckPropertyKeys.java
@@ -11,4 +11,8 @@ public class LicenseCheckPropertyKeys
     public static final String PROJECT_LICENSE_KEY = "licensecheck.projectlicense";
 
     public static final String NPM_RESOLVE_TRANSITIVE_DEPS = "licensecheck.npm.resolvetransitive";
+
+    public static final String CUSTOM_LICENSE_MAPPINGS = "licensecheck.custommappings";
+
+    public static final String FORCED_LICENSE_MAPPINGS = "licensecheck.forcemappings";
 }


### PR DESCRIPTION
Especially in npm packages we sometimes stumble upon package.json files where the license identifier is either not set at all or doesn't comply with SPDX specification. 

We've seen things like "SEE LICENSE IN LICENSE file", "SAP DEVELOPER LICENSE AGREEMENT" and such. 

As this occurs in only a few packages we decided to just implement a simple mapping functionality for setting a license identifier where one is missing or even force an identifier where we know a malformed one is used. 

Mappings can be passed either as JSON array to be more maintainable or in a more compact inline format. 

JSON example: 
`
[
  {"dependency":"somepackage", "license":"MIT"},
  {"dependency":"someotherpackage", "license":"Apache-2.0"}
]
`

Inline example:
`somepackage;MIT$someotherpackage;Apache-2.0$onemore-package;MIT`