### PR TITLE
removed else block preventing overriding functionality from working

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -46,10 +46,8 @@ public class ValidateLicenses
             {
                 mapDependencyToLicense(dependencyMappings, dependency);
             }
-            else
-            {
-                overrideLicenseForDependency(dependencyMappings, dependency);
-            }
+
+            overrideLicenseForDependency(dependencyMappings, dependency);
 
             if (!isLicensesValid(context, licenses, dependency))
             {


### PR DESCRIPTION
Hi there, 

unfortunately I didn't have time to reach out to you earlier or dig any deeper into this issue. What I found was that licenses which are defined using a wrong identifier are still not overridden and mapped while a mapping exists with the respective flag set. Only those without any identifier are. Removing the else block as I did in this pull request fixed the issue for me.