### PR TITLE
feat(ts): Enable licensecheck rule for package.json in typescript

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinition.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinition.java
@@ -10,11 +10,13 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition
 {
     public static final String LANG_JAVA = "java";
     public static final String LANG_JS = "js";
+    public static final String LANG_TS = "ts";
     public static final String LANG_GROOVY = "grvy";
     public static final String LANG_KOTLIN = "kotlin";
 
     public static final String RULE_REPO_KEY = "licensecheck";
     public static final String RULE_REPO_KEY_JS = "licensecheck-js";
+    public static final String RULE_REPO_KEY_TS = "licensecheck-ts";
     public static final String RULE_REPO_KEY_GROOVY = "licensecheck-groovy";
     public static final String RULE_REPO_KEY_KOTLIN = "licensecheck-kotlin";
 
@@ -27,6 +29,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition
         NewRepository[] repos = new NewRepository[]{
             context.createRepository(RULE_REPO_KEY, LANG_JAVA),
             context.createRepository(RULE_REPO_KEY_JS, LANG_JS),
+            context.createRepository(RULE_REPO_KEY_TS, LANG_TS),
             context.createRepository(RULE_REPO_KEY_GROOVY, LANG_GROOVY),
             context.createRepository(RULE_REPO_KEY_KOTLIN, LANG_KOTLIN),
         };

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
@@ -3,6 +3,7 @@ package at.porscheinformatik.sonarqube.licensecheck;
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY;
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY_GROOVY;
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY_JS;
+import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY_TS;
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY_KOTLIN;
 
 import java.util.Set;
@@ -114,6 +115,7 @@ public class LicenseCheckSensor implements Sensor
         descriptor.name("License Check").createIssuesForRuleRepositories(
             RULE_REPO_KEY,
             RULE_REPO_KEY_JS,
+            RULE_REPO_KEY_TS,
             RULE_REPO_KEY_GROOVY,
             RULE_REPO_KEY_KOTLIN);
     }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -249,6 +249,8 @@ public class ValidateLicenses
         {
             case LicenseCheckRulesDefinition.LANG_JS:
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY_JS;
+            case LicenseCheckRulesDefinition.LANG_TS:
+                return LicenseCheckRulesDefinition.RULE_REPO_KEY_TS;
             case LicenseCheckRulesDefinition.LANG_GROOVY:
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY_GROOVY;
             case LicenseCheckRulesDefinition.LANG_JAVA:

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinitionTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinitionTest.java
@@ -15,7 +15,7 @@ public class LicenseCheckRulesDefinitionTest
 
         new LicenseCheckRulesDefinition().define(context);
 
-        assertThat(context.repositories().size(), is(4));
+        assertThat(context.repositories().size(), is(5));
         for (RulesDefinition.Repository repository : context.repositories())
         {
             assertThat(repository.rules().size(), is(2));


### PR DESCRIPTION
Typescript uses the exact same tooling as NodeJS. Same node, npm, `package.json`, dependencies.

But sonarqube has separate quality profiles for nodejs & typescript, even though everything else (including the code analysis) is the same. sonarqube-licensecheck has no rule for `ts`, so it doesn't execute. License check output in the project is empty even though the package.json is eligible for scanning.

### Proposal

To register and enable licensecheck rule for `ts`. There is no code change needed, this is just like what was done for kotlin here. We just register a rule and let the normal plugin execution do it's work, since it only looks at the `package.json`.