### PR TITLE
improving logging info for unmatched license name

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -280,7 +280,8 @@ public class MavenDependencyScanner implements Scanner
             }
         }
 
-        LOGGER.info("No licenses match found for '{}'", licenseName);
+        LOGGER.info("No licenses match found for '{}' in dependency '{}:{}'", licenseName,
+            dependency.getName(), dependency.getVersion());
     }
 
     private static MavenSettings getSettingsFromCommandLineArgs()


### PR DESCRIPTION
In case there are several dependencies that could correspond to an unmatched license name it is hard to determine which is at fault and what action to take.

This PR aims to improve the details of logging this situation by specifying the dependency's name and version.