### PR TITLE
adding feature to match maven dependencies by version also

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/Dependency.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/Dependency.java
@@ -1,6 +1,6 @@
 package at.porscheinformatik.sonarqube.licensecheck;
 
-import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.LANG_JAVA;
+import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.*;
 
 import java.io.StringWriter;
 import java.util.Collection;
@@ -51,6 +51,19 @@ public class Dependency implements Comparable<Dependency>
     public String getVersion()
     {
         return version;
+    }
+
+    public String getNameWithVersion(){
+        switch (this.lang){
+            case LANG_JS:
+            case LANG_TS:
+                return this.name + "@" + this.version;
+            case LANG_JAVA:
+            case LANG_GROOVY:
+            case LANG_KOTLIN:
+            default:
+                return this.name + ":" + this.version;
+        }
     }
 
     public void setVersion(String version)

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -99,7 +99,8 @@ public class ValidateLicenses
             if (StringUtils.isBlank(dependency.getLicense()))
             {
                 String matchString = dependencyMapping.getKey();
-                if (dependency.getName().matches(matchString))
+                if (dependency.getName().matches(matchString) ||
+                    dependency.getNameWithVersion().matches(matchString))
                 {
                     dependency.setLicense(dependencyMapping.getLicense());
                 }


### PR DESCRIPTION
Feature allowing maven dependency matching by also using the version of the library. Some libraries, for example iText, switched licensing from one version to another:
https://github.com/ymasory/iText-4.2.0 (v4.x used LGPL/MPL) while from v5.x onward uses AGPL -> https://mvnrepository.com/artifact/com.itextpdf/itextpdf

Therefore there are cases when you want to match a certain library *and version* to a certain license, but not for all versions of the library.

I have tried to implement the feature with as little side-effects as possible, what has been matching will continue to match, at most it would match something that it didn't use to match. Maybe, if needed, a visual UI setting such as "use version too when matching" could be added.