### PR TITLE
Improving NPM scan resilience

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/npm/PackageJsonDependencyScanner.java
@@ -47,11 +47,12 @@ public class PackageJsonDependencyScanner implements Scanner
 
         Set<Dependency> allDependencies = new HashSet<>();
 
+        LOGGER.info("Scanning for NPM dependencies (dir={})", fs.baseDir());
         for (InputFile packageJsonFile : fs.inputFiles(packageJsonPredicate))
         {
             context.markForPublishing(packageJsonFile);
 
-            LOGGER.info("Scanning for NPM dependencies (dir={})", fs.baseDir());
+            LOGGER.info("Scanning package.json: (path={})", packageJsonFile);
             allDependencies.addAll(dependencyParser(fs.baseDir(), packageJsonFile));
         }
 
@@ -78,7 +79,7 @@ public class PackageJsonDependencyScanner implements Scanner
                 });
             }
         }
-        catch (IOException e)
+        catch (Exception e)
         {
             LOGGER.error("Error reading package.json", e);
         }


### PR DESCRIPTION
Currently malformed package.json files (which NPM can handle somehow...) will bring down the whole scanning process like so:

21:08:58 14:08:57.978 ERROR: Error during SonarQube Scanner execution
21:08:58 javax.json.stream.JsonParsingException: Invalid token=EOF at (line no=2, column no=4, offset=5). Expected tokens are: [STRING, CURLYCLOSE]
21:08:58 	at org.glassfish.json.JsonParserImpl.parsingException(JsonParserImpl.java:450)
21:08:58 	at org.glassfish.json.JsonParserImpl.access$1100(JsonParserImpl.java:79)
21:08:58 	at org.glassfish.json.JsonParserImpl$ObjectContext.getNextEvent(JsonParserImpl.java:470)
21:08:58 	at org.glassfish.json.JsonParserImpl.hasNext(JsonParserImpl.java:365)
21:08:58 	at org.glassfish.json.JsonParserImpl.getObject(JsonParserImpl.java:334)
21:08:58 	at org.glassfish.json.JsonParserImpl.getObject(JsonParserImpl.java:173)
21:08:58 	at org.glassfish.json.JsonReaderImpl.readObject(JsonReaderImpl.java:112)
21:08:58 	at at.porscheinformatik.sonarqube.licensecheck.npm.PackageJsonDependencyScanner.dependencyParser(PackageJsonDependencyScanner.java:68)
21:08:58 	at at.porscheinformatik.sonarqube.licensecheck.npm.PackageJsonDependencyScanner.scan(PackageJsonDependencyScanner.java:55)
21:08:58 	at at.porscheinformatik.sonarqube.licensecheck.LicenseCheckSensor.execute(LicenseCheckSensor.java:136)
21:08:58 	at org.sonar.scanner.sensor.AbstractSensorWrapper.analyse(AbstractSensorWrapper.java:48)
21:08:58 	at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:85)
21:08:58 	at org.sonar.scanner.sensor.ModuleSensorsExecutor.lambda$execute$1(ModuleSensorsExecutor.java:59)
21:08:58 	at org.sonar.scanner.sensor.ModuleSensorsExecutor.withModuleStrategy(ModuleSensorsExecutor.java:77)
21:08:58 	at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:59)
21:08:58 	at org.sonar.scanner.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:82)
21:08:58 	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:137)
21:08:58 	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:123)
21:08:58 	at org.sonar.scanner.scan.ProjectScanContainer.scan(ProjectScanContainer.java:392)
21:08:58 	at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:388)
21:08:58 	at org.sonar.scanner.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:357)
21:08:58 	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:137)
21:08:58 	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:123)
21:08:58 	at org.sonar.scanner.bootstrap.GlobalContainer.doAfterStart(GlobalContainer.java:150)
21:08:58 	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:137)
21:08:58 	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:123)
21:08:58 	at org.sonar.batch.bootstrapper.Batch.doExecute(Batch.java:72)
21:08:58 	at org.sonar.batch.bootstrapper.Batch.execute(Batch.java:66)
21:08:58 	at org.sonarsource.scanner.api.internal.batch.BatchIsolatedLauncher.execute(BatchIsolatedLauncher.java:46)
21:08:58 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
21:08:58 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
21:08:58 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
21:08:58 	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
21:08:58 	at org.sonarsource.scanner.api.internal.IsolatedLauncherProxy.invoke(IsolatedLauncherProxy.java:60)
21:08:58 	at com.sun.proxy.$Proxy0.execute(Unknown Source)
21:08:58 	at org.sonarsource.scanner.api.EmbeddedScanner.doExecute(EmbeddedScanner.java:185)
21:08:58 	at org.sonarsource.scanner.api.EmbeddedScanner.execute(EmbeddedScanner.java:137)
21:08:58 	at org.sonarsource.scanner.cli.Main.execute(Main.java:112)
21:08:58 	at org.sonarsource.scanner.cli.Main.execute(Main.java:75)
21:08:58 	at org.sonarsource.scanner.cli.Main.main(Main.java:61)


This PR aims to fix this and improve logging details for NPM scanning.