### PR TITLE
Improve "unlisted license" issue message

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -221,10 +221,11 @@ public class ValidateLicenses
 
     private static void licenseNotFoundIssue(SensorContext context, Dependency dependency)
     {
-        LOGGER.info("No License found for Dependency " + dependency.getName());
+        String message = String.format("Unlisted License for dependency %s: %s", dependency.getName(), dependency.getLicense());
+        LOGGER.info(message);
 
         createIssue(context, dependency, LicenseCheckRulesDefinition.RULE_UNLISTED_KEY,
-            "No License found for Dependency: " + dependency.getName());
+            message);
     }
 
     private static void createIssue(SensorContext context, Dependency dependency, String rule, String message)

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -221,7 +221,7 @@ public class ValidateLicenses
 
     private static void licenseNotFoundIssue(SensorContext context, Dependency dependency)
     {
-        String message = String.format("Unlisted License for dependency %s: %s", dependency.getName(), dependency.getLicense());
+        String message = String.format("No License found for Dependency %s (license from source: %s)", dependency.getName(), dependency.getLicense());
         LOGGER.info(message);
 
         createIssue(context, dependency, LicenseCheckRulesDefinition.RULE_UNLISTED_KEY,

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -221,11 +221,11 @@ public class ValidateLicenses
 
     private static void licenseNotFoundIssue(SensorContext context, Dependency dependency)
     {
-        String message = String.format("No License found for Dependency %s (license from source: %s)", dependency.getName(), dependency.getLicense());
+        String message = String.format("No License found for Dependency %s (license from source: %s)",
+            dependency.getName(), dependency.getLicense());
         LOGGER.info(message);
 
-        createIssue(context, dependency, LicenseCheckRulesDefinition.RULE_UNLISTED_KEY,
-            message);
+        createIssue(context, dependency, LicenseCheckRulesDefinition.RULE_UNLISTED_KEY, message);
     }
 
     private static void createIssue(SensorContext context, Dependency dependency, String rule, String message)


### PR DESCRIPTION
This helps identifying which license is missing from configuration without needing to check the log file.