### PR TITLE
Dependency mapping "overwrite" should default to true

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: adopt
+          java-version: 17
+          distribution: temurin
       - name: Build with SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.1](https://github.com/porscheinformatik/sonarqube-licensecheck/compare/v6.0.0...v6.0.1) - 2024-01-26
+
+### Bug Fixes
+
+- Dependency mapping "overwrite" should default to true (#413)
+
 ## [6.0.0](https://github.com/porscheinformatik/sonarqube-licensecheck/compare/v5.1.1...v6.0.0) - 2023-12-15
 
 ### BREAKING CHANGES

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/dependencymapping/DependencyMappingService.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/dependencymapping/DependencyMappingService.java
@@ -36,7 +36,7 @@ public class DependencyMappingService {
                     .orElse(null);
                 Boolean overwrite = configuration
                     .getBoolean(DEPENDENCY_MAPPING + idxProp + FIELD_OVERWRITE)
-                    .orElse(Boolean.FALSE);
+                    .orElse(Boolean.TRUE);
                 return new DependencyMapping(key, license, overwrite);
             })
             .collect(Collectors.toList());

--- a/src/main/web/configuration/dependency-mappings-page.vue
+++ b/src/main/web/configuration/dependency-mappings-page.vue
@@ -76,7 +76,7 @@
             <td>{{ item.key }}</td>
             <td>{{ item.license }} / {{ findLicenseName(item.license) }}</td>
             <td>
-              {{ item.overwrite === "true" ? "Yes" : "No" }}
+              {{ item.overwrite === "false" ? "No" : "Yes" }}
             </td>
             <td class="thin nowrap">
               <a class="button" @click="showEditDialog(item)" title="Edit item">


### PR DESCRIPTION
This fixes backward compatability: older versions did not have that flag and always took the dependency mapping before all others.

Fixes #412