### PR TITLE
fix: passing local Maven repo to sub-process

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -126,6 +126,9 @@ public class MavenDependencyScanner implements Scanner {
                     LOGGER.warn("Could not find mvn in path");
                 }
             }
+            if (System.getenv("MAVEN_OPTS") != null) {
+                request.setMavenOpts(System.getenv("MAVEN_OPTS"));
+            }
             request.setOutputHandler(line -> {
                 if (line.startsWith("[ERROR] ")) {
                     mavenExecutionErrors.append(line.substring(8)).append(System.lineSeparator());


### PR DESCRIPTION
When the -Dmaven.repo.local is set in MAVEN_OPTS the dependency scanner cannot find parents and therefore not resolve the license correctly. This change fixes this by inheriting the MAVEN_OPTS from the parent process.

This fixex #449