### PR TITLE
fix: also use maven.repo.local inside MAVEN_OPTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.2](https://github.com/porscheinformatik/sonarqube-licensecheck/compare/v7.0.1...v7.0.2) - 2025-06-23
+
+### Bug Fixes
+
+- Also check maven.repo.local is set via MAVEN_OPTS in License finding (#451)
+
 ## [7.0.1](https://github.com/porscheinformatik/sonarqube-licensecheck/compare/v7.0.0...v7.0.1) - 2025-06-23
 
 ### Bug Fixes

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinder.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinder.java
@@ -2,8 +2,13 @@ package at.porscheinformatik.sonarqube.licensecheck.maven;
 
 import at.porscheinformatik.sonarqube.licensecheck.Dependency;
 import java.io.File;
+import org.apache.maven.shared.utils.cli.CommandLineUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DirectoryFinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DirectoryFinder.class);
 
     private DirectoryFinder() {}
 
@@ -30,6 +35,21 @@ class DirectoryFinder {
     public static File getMavenRepsitoryDir(String userSettings, String globalSettings) {
         if (System.getProperty("maven.repo.local") != null) {
             return new File(System.getProperty("maven.repo.local"));
+        }
+        String mavenOpts = System.getenv("MAVEN_OPTS");
+        if (mavenOpts != null) {
+            try {
+                String[] opts = CommandLineUtils.translateCommandline(mavenOpts);
+                for (String opt : opts) {
+                    if (opt.startsWith("-Dmaven.repo.local=")) {
+                        String repoPath = opt.substring("-Dmaven.repo.local=".length());
+                        return new File(repoPath);
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Could not parse MAVEN_OPTS: " + mavenOpts, e);
+                // ignore
+            }
         }
 
         File mavenConfFile = new File(System.getProperty("user.home"), ".m2/settings.xml");

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -105,6 +105,10 @@ public class MavenDependencyScanner implements Scanner {
         if (System.getProperty(MAVEN_REPO_LOCAL) != null) {
             properties.setProperty(MAVEN_REPO_LOCAL, System.getProperty(MAVEN_REPO_LOCAL));
         }
+        if (System.getenv("MAVEN_OPTS") != null) {
+            request.setMavenOpts(System.getenv("MAVEN_OPTS"));
+        }
+        request.setBatchMode(true);
         request.setProperties(properties);
 
         return invokeMaven(request, tempFile);
@@ -125,9 +129,6 @@ public class MavenDependencyScanner implements Scanner {
                 } else {
                     LOGGER.warn("Could not find mvn in path");
                 }
-            }
-            if (System.getenv("MAVEN_OPTS") != null) {
-                request.setMavenOpts(System.getenv("MAVEN_OPTS"));
             }
             request.setOutputHandler(line -> {
                 if (line.startsWith("[ERROR] ")) {

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinderTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinderTest.java
@@ -1,0 +1,22 @@
+package at.porscheinformatik.sonarqube.licensecheck.maven;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import org.junit.Test;
+
+public class DirectoryFinderTest {
+
+    @Test
+    public void checkMavenRepoLocal() {
+        String mavenRepoLocalOld = System.getProperty("maven.repo.local");
+        System.setProperty("maven.repo.local", "/tmp/maven-repo");
+        File repoDir = DirectoryFinder.getMavenRepsitoryDir(null, null);
+        if (mavenRepoLocalOld != null) {
+            System.setProperty("maven.repo.local", mavenRepoLocalOld);
+        } else {
+            System.clearProperty("maven.repo.local");
+        }
+        assertEquals(repoDir.getAbsolutePath(), "/tmp/maven-repo");
+    }
+}


### PR DESCRIPTION
This pull request introduces enhancements to the Maven repository directory resolution logic and adds new unit tests to ensure reliability. Key changes include the addition of support for parsing `MAVEN_OPTS` environment variables, improved error handling, and a new test class for the `DirectoryFinder` utility.

### Enhancements to Maven repository directory resolution:

* [`src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinder.java`](diffhunk://#diff-f1c33b35a33d25683fd9d2ca765a31e283b32c6fd537c759b4423e0865400156R39-R53): Added logic to parse the `MAVEN_OPTS` environment variable for `-Dmaven.repo.local` configurations, with fallback handling and logging for parsing errors.
* [`src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java`](diffhunk://#diff-0e64887a51d6c8125036a3330c1faf09576c546a6f83ecbad4d4e470d0a31665R108-R111): Updated `readDependencyList` to set `MAVEN_OPTS` and enable batch mode in the Maven invocation request. Removed redundant `MAVEN_OPTS` handling from `invokeMaven`. [[1]](diffhunk://#diff-0e64887a51d6c8125036a3330c1faf09576c546a6f83ecbad4d4e470d0a31665R108-R111) [[2]](diffhunk://#diff-0e64887a51d6c8125036a3330c1faf09576c546a6f83ecbad4d4e470d0a31665L129-L131)

### Logging improvements:

* [`src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinder.java`](diffhunk://#diff-f1c33b35a33d25683fd9d2ca765a31e283b32c6fd537c759b4423e0865400156R5-R12): Introduced a `Logger` to log warnings when `MAVEN_OPTS` parsing fails.

### Unit test additions:

* [`src/test/java/at/porscheinformatik/sonarqube/licensecheck/maven/DirectoryFinderTest.java`](diffhunk://#diff-f9f3232cb2563362322529fe5df1a44f2d06ec0391cde6e1a6ceacf1cf3536d7R1-R22): Added a new test class, `DirectoryFinderTest`, with a test method to verify the resolution of the `maven.repo.local` system property.

Fixes #451