### PR TITLE
Add Python and .NET support for license check plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This software is licensed under the [Apache Software License, Version 2.0](http:
   - [NPM](#npm)
   - [Gradle](#gradle)
 - [Configuration via Sonar API](#configuration-via-sonar-api)
+- [License Check Integration (Python & .NET)](#license-check-integration-python--net)
 <!-- TOC -->
 
 ## Features
@@ -304,3 +305,11 @@ curl -X GET -v -u USERNAME:PASSWORD "http://localhost:9000/api/settings/values?k
   ```
   curl -X POST -v -u USERNAME:PASSWORD "http://localhost:9000/api/settings/set?key=licensecheck.npm.resolvetransitive&value=false"
   ```
+
+## License Check Integration (Python & .NET)
+
+See [docs/licensecheck_integration_guide.md](docs/licensecheck_integration_guide.md) for instructions on integrating license checks for Python and .NET projects.
+
+- Python: Use pip-license-check to generate `tests/reports/python-licenses.json`.
+- .NET: Use dotnet-project-licenses to generate `tests/reports/dotnet-licenses.json`.
+- Ensure output files are in the correct format and location for automatic detection by the plugin.

--- a/README.md
+++ b/README.md
@@ -308,8 +308,10 @@ curl -X GET -v -u USERNAME:PASSWORD "http://localhost:9000/api/settings/values?k
 
 ## License Check Integration (Python & .NET)
 
-See [docs/licensecheck_integration_guide.md](docs/licensecheck_integration_guide.md) for instructions on integrating license checks for Python and .NET projects.
-
-- Python: Use pip-license-check to generate `tests/reports/python-licenses.json`.
+- Python: Use `licensecheck` (2025.1.0+) to generate `tests/reports/python-licenses.json`:
+  ```bash
+  pip install licensecheck
+  licensecheck --output tests/reports/python-licenses.json
+  ```
 - .NET: Use dotnet-project-licenses to generate `tests/reports/dotnet-licenses.json`.
 - Ensure output files are in the correct format and location for automatic detection by the plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 
   <groupId>at.porscheinformatik.sonarqube.licensecheck</groupId>
   <artifactId>sonarqube-licensecheck-plugin</artifactId>
-  <version>7.0.0-SNAPSHOT</version>
+  <version>7.0.1-AVEPOINT</version>
   <name>SonarQube License Check Plugin</name>
   <packaging>sonar-plugin</packaging>
 
   <description>Checks Maven and NPM dependencies against a defined set of allowed licenses and reports any unknown or
     not allowed licenses as an issue.
   </description>
-  <url>https://github.com/porscheinformatik/sonarqube-licensecheck</url>
+  <url>https://github.com/hagan-tran-avepoint/sonarqube-licensecheck</url>
 
   <organization>
     <name>Porsche Informatik</name>
@@ -27,11 +27,16 @@
     <developer>
       <name>Stephanie Kaschnitz</name>
     </developer>
+    <developer>
+      <id>hagan-tran-avepoint</id>
+      <name>Hagan Tran</name>
+      <email>hagan.tran@avepoint.com</email>
+    </developer>
   </developers>
 
   <issueManagement>
     <system>github</system>
-    <url>https://github.com/porscheinformatik/sonarqube-licensecheck/issues</url>
+    <url>https://github.com/hagan-tran-avepoint/sonarqube-licensecheck/issues</url>
   </issueManagement>
 
   <licenses>
@@ -117,9 +122,9 @@
   </dependencies>
 
   <scm>
-    <connection>scm:git:https://github.com/porscheinformatik/sonarqube-licensecheck.git</connection>
-    <developerConnection>https://github.com/porscheinformatik/sonarqube-licensecheck.git</developerConnection>
-    <url>https://github.com/porscheinformatik/sonarqube-licensecheck</url>
+    <connection>scm:git:https://github.com/hagan-tran-avepoint/sonarqube-licensecheck.git</connection>
+    <developerConnection>https://github.com/hagan-tran-avepoint/sonarqube-licensecheck.git</developerConnection>
+    <url>https://github.com/hagan-tran-avepoint/sonarqube-licensecheck</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/Dependency.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/Dependency.java
@@ -145,7 +145,10 @@ public class Dependency implements Comparable<Dependency> {
             String license = dependency.getLicense();
             generator.writeStartObject();
             generator.write("name", dependency.getName());
-            generator.write("version", dependency.getVersion());
+            generator.write(
+                "version",
+                dependency.getVersion() != null ? dependency.getVersion() : "unknown-version"
+            );
             generator.write("license", license != null ? license : " ");
             generator.write("lang", dependency.getLang());
             generator.writeEnd();

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckLanguage.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckLanguage.java
@@ -1,0 +1,27 @@
+package at.porscheinformatik.sonarqube.licensecheck;
+
+/**
+ * A language enum definition, in order to handle multiple languages & repositories
+ */
+public enum LicenseCheckLanguage {
+    DART("dart"),
+    JAVA("java"),
+    JAVASCRIPT("javascript"),
+    SWIFT("swift"),
+    PYTHON("python");
+
+    private String language;
+
+    LicenseCheckLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getLanguage() {
+        return language.toLowerCase();
+    }
+
+    @Override
+    public String toString() {
+        return language;
+    }
+}

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckLanguage.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckLanguage.java
@@ -8,6 +8,7 @@ public enum LicenseCheckLanguage {
     JAVA("java"),
     JAVASCRIPT("javascript"),
     SWIFT("swift"),
+    DOTNET("dotnet"),
     PYTHON("python");
 
     private String language;

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinition.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinition.java
@@ -14,6 +14,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition {
     public static final String LANG_GROOVY = "grvy";
     public static final String LANG_KOTLIN = "kotlin";
     public static final String LANG_SCALA = "scala";
+    public static final String LANG_PYTHON = "python";
 
     public static final String RULE_REPO_KEY = "licensecheck";
     public static final String RULE_REPO_KEY_JS = "licensecheck-js";
@@ -21,6 +22,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition {
     public static final String RULE_REPO_KEY_GROOVY = "licensecheck-groovy";
     public static final String RULE_REPO_KEY_KOTLIN = "licensecheck-kotlin";
     public static final String RULE_REPO_KEY_SCALA = "licensecheck-scala";
+    public static final String RULE_REPO_KEY_PYTHON = "licensecheck-python";
 
     public static final String RULE_UNLISTED_KEY = "licensecheck.unlisted";
     public static final String RULE_NOT_ALLOWED_LICENSE_KEY = "licensecheck.notallowedlicense";
@@ -34,6 +36,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition {
             context.createRepository(RULE_REPO_KEY_GROOVY, LANG_GROOVY),
             context.createRepository(RULE_REPO_KEY_KOTLIN, LANG_KOTLIN),
             context.createRepository(RULE_REPO_KEY_SCALA, LANG_SCALA),
+            context.createRepository(RULE_REPO_KEY_PYTHON, LANG_PYTHON),
         };
 
         for (NewRepository repo : repos) {

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinition.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinition.java
@@ -14,6 +14,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition {
     public static final String LANG_GROOVY = "grvy";
     public static final String LANG_KOTLIN = "kotlin";
     public static final String LANG_SCALA = "scala";
+    public static final String LANG_DOTNET = "dotnet";
     public static final String LANG_PYTHON = "python";
 
     public static final String RULE_REPO_KEY = "licensecheck";
@@ -22,6 +23,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition {
     public static final String RULE_REPO_KEY_GROOVY = "licensecheck-groovy";
     public static final String RULE_REPO_KEY_KOTLIN = "licensecheck-kotlin";
     public static final String RULE_REPO_KEY_SCALA = "licensecheck-scala";
+    public static final String RULE_REPO_KEY_DOTNET = "licensecheck-dotnet";
     public static final String RULE_REPO_KEY_PYTHON = "licensecheck-python";
 
     public static final String RULE_UNLISTED_KEY = "licensecheck.unlisted";
@@ -37,6 +39,7 @@ public final class LicenseCheckRulesDefinition implements RulesDefinition {
             context.createRepository(RULE_REPO_KEY_KOTLIN, LANG_KOTLIN),
             context.createRepository(RULE_REPO_KEY_SCALA, LANG_SCALA),
             context.createRepository(RULE_REPO_KEY_PYTHON, LANG_PYTHON),
+            context.createRepository(RULE_REPO_KEY_DOTNET, LANG_DOTNET),
         };
 
         for (NewRepository repo : repos) {

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
@@ -1,4 +1,4 @@
-package at.porscheinformatik.sonarqube.licensecheck;
+npx prettier --write .package at.porscheinformatik.sonarqube.licensecheck;
 
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY;
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY_GROOVY;
@@ -7,6 +7,7 @@ import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefin
 import static at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition.RULE_REPO_KEY_TS;
 import static java.util.function.Predicate.not;
 
+import at.porscheinformatik.sonarqube.licensecheck.dotnet.DotnetDependencyScanner;
 import at.porscheinformatik.sonarqube.licensecheck.gradle.GradleDependencyScanner;
 import at.porscheinformatik.sonarqube.licensecheck.license.License;
 import at.porscheinformatik.sonarqube.licensecheck.licensemapping.LicenseMappingService;
@@ -51,6 +52,7 @@ public class LicenseCheckSensor implements Sensor {
                 new MavenDependencyScanner(licenseMappingService),
                 new GradleDependencyScanner(licenseMappingService),
                 new PythonDependencyScanner(licenseMappingService),
+                new DotnetDependencyScanner(licenseMappingService),
             };
     }
 
@@ -148,7 +150,8 @@ public class LicenseCheckSensor implements Sensor {
                 RULE_REPO_KEY_TS,
                 RULE_REPO_KEY_GROOVY,
                 RULE_REPO_KEY_KOTLIN,
-                LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON
+                LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON,
+                LicenseCheckRulesDefinition.RULE_REPO_KEY_DOTNET
             );
     }
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensor.java
@@ -12,6 +12,7 @@ import at.porscheinformatik.sonarqube.licensecheck.license.License;
 import at.porscheinformatik.sonarqube.licensecheck.licensemapping.LicenseMappingService;
 import at.porscheinformatik.sonarqube.licensecheck.maven.MavenDependencyScanner;
 import at.porscheinformatik.sonarqube.licensecheck.npm.PackageJsonDependencyScanner;
+import at.porscheinformatik.sonarqube.licensecheck.python.PythonDependencyScanner;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +50,7 @@ public class LicenseCheckSensor implements Sensor {
                 ),
                 new MavenDependencyScanner(licenseMappingService),
                 new GradleDependencyScanner(licenseMappingService),
+                new PythonDependencyScanner(licenseMappingService),
             };
     }
 
@@ -145,7 +147,8 @@ public class LicenseCheckSensor implements Sensor {
                 RULE_REPO_KEY_JS,
                 RULE_REPO_KEY_TS,
                 RULE_REPO_KEY_GROOVY,
-                RULE_REPO_KEY_KOTLIN
+                RULE_REPO_KEY_KOTLIN,
+                LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON
             );
     }
 

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -62,9 +62,11 @@ public class ValidateLicenses {
         Set<License> usedLicenseList = new TreeSet<>();
 
         for (Dependency dependency : dependencies) {
-            for (License license : licenses) {
-                if (license.getIdentifier().equals(dependency.getLicense())) {
-                    usedLicenseList.add(license);
+            if (licenses != null && !licenses.isEmpty()) {
+                for (License license : licenses) {
+                    if (license.getIdentifier().equals(dependency.getLicense())) {
+                        usedLicenseList.add(license);
+                    }
                 }
             }
         }
@@ -254,6 +256,9 @@ public class ValidateLicenses {
             case LicenseCheckRulesDefinition.LANG_KOTLIN:
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY_KOTLIN;
             case LicenseCheckRulesDefinition.LANG_JAVA:
+                return LicenseCheckRulesDefinition.RULE_REPO_KEY;
+            case LicenseCheckRulesDefinition.LANG_PYTHON:
+                return LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON;
             default:
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY;
         }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/ValidateLicenses.java
@@ -259,6 +259,8 @@ public class ValidateLicenses {
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY;
             case LicenseCheckRulesDefinition.LANG_PYTHON:
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON;
+            case LicenseCheckRulesDefinition.LANG_DOTNET:
+                return LicenseCheckRulesDefinition.RULE_REPO_KEY_DOTNET;
             default:
                 return LicenseCheckRulesDefinition.RULE_REPO_KEY;
         }

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/dotnet/DotnetDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/dotnet/DotnetDependencyScanner.java
@@ -1,4 +1,4 @@
-package at.porscheinformatik.sonarqube.licensecheck.python;
+package at.porscheinformatik.sonarqube.licensecheck.dotnet;
 
 import at.porscheinformatik.sonarqube.licensecheck.Dependency;
 import at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition;
@@ -22,12 +22,12 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
-public class PythonDependencyScanner implements Scanner {
+public class DotnetDependencyScanner implements Scanner {
 
-    private static final Logger LOGGER = Loggers.get(PythonDependencyScanner.class);
+    private static final Logger LOGGER = Loggers.get(DotnetDependencyScanner.class);
     private final LicenseMappingService licenseMappingService;
 
-    public PythonDependencyScanner(LicenseMappingService licenseMappingService) {
+    public DotnetDependencyScanner(LicenseMappingService licenseMappingService) {
         this.licenseMappingService = licenseMappingService;
     }
 
@@ -37,11 +37,11 @@ public class PythonDependencyScanner implements Scanner {
         Map<Pattern, String> defaultLicenseMap = licenseMappingService.getLicenseMap();
         File licenseDetailsJsonFile = new File(
             moduleDir,
-            "tests" + File.separator + "reports" + File.separator + "python-licenses.json"
+            "tests" + File.separator + "reports" + File.separator + "dotnet-licenses.json"
         );
         if (!licenseDetailsJsonFile.exists()) {
             LOGGER.info(
-                "No license-details.json file found in {} - skipping Python dependency scan",
+                "No dotnet-licenses.json file found in {} - skipping .NET dependency scan",
                 licenseDetailsJsonFile.getPath()
             );
             return Collections.emptySet();
@@ -59,15 +59,12 @@ public class PythonDependencyScanner implements Scanner {
             InputStream fis = new FileInputStream(licenseDetailsJsonFile);
             JsonReader jsonReader = Json.createReader(fis)
         ) {
-            JsonObject jo = jsonReader.readObject();
-            JsonArray arr = jo.getJsonArray("packages");
-            if (arr != null) {
-                prepareDependencySet(dependencySet, arr);
-            }
+            JsonArray arr = jsonReader.readArray();
+            prepareDependencySet(dependencySet, arr);
             return dependencySet;
         } catch (Exception e) {
             LOGGER.error(
-                "Problems reading Python license file {}: {}",
+                "Problems reading .NET license file {}: {}",
                 licenseDetailsJsonFile.getPath(),
                 e.getMessage()
             );
@@ -78,15 +75,15 @@ public class PythonDependencyScanner implements Scanner {
     private void prepareDependencySet(Set<Dependency> dependencySet, JsonArray arr) {
         for (javax.json.JsonValue entry : arr) {
             JsonObject jsonDepObj = entry.asJsonObject();
-            String license = jsonDepObj.getString("license", null);
-            String name = jsonDepObj.getString("name", null);
-            String version = jsonDepObj.getString("version", null);
-            String url = jsonDepObj.getString("homePage", null);
+            String license = jsonDepObj.getString("LicenseType", null);
+            String name = jsonDepObj.getString("PackageName", null);
+            String version = jsonDepObj.getString("PackageVersion", null);
+            String url = jsonDepObj.getString("PackageUrl", null);
             Dependency dep = new Dependency(
                 name,
                 version,
                 license,
-                LicenseCheckRulesDefinition.LANG_PYTHON
+                LicenseCheckRulesDefinition.LANG_DOTNET
             );
             dep.setPomPath(url);
             dependencySet.add(dep);

--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/python/PythonDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/python/PythonDependencyScanner.java
@@ -1,0 +1,137 @@
+package at.porscheinformatik.sonarqube.licensecheck.python;
+
+import at.porscheinformatik.sonarqube.licensecheck.Dependency;
+import at.porscheinformatik.sonarqube.licensecheck.LicenseCheckRulesDefinition;
+import at.porscheinformatik.sonarqube.licensecheck.Scanner;
+import at.porscheinformatik.sonarqube.licensecheck.licensemapping.LicenseMappingService;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import org.codehaus.plexus.util.StringUtils;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+public class PythonDependencyScanner implements Scanner {
+
+    private static final Logger LOGGER = Loggers.get(PythonDependencyScanner.class);
+    private final LicenseMappingService licenseMappingService;
+
+    public PythonDependencyScanner(LicenseMappingService licenseMappingService) {
+        this.licenseMappingService = licenseMappingService;
+    }
+
+    @Override
+    public Set<Dependency> scan(SensorContext context) {
+        File moduleDir = context.fileSystem().baseDir();
+        Map<Pattern, String> defaultLicenseMap = licenseMappingService.getLicenseMap();
+        File licenseDetailsJsonFile = new File(
+            moduleDir,
+            "build" +
+            File.separator +
+            "reports" +
+            File.separator +
+            "dependency-license" +
+            File.separator +
+            "license-details.json"
+        );
+        if (!licenseDetailsJsonFile.exists()) {
+            LOGGER.info(
+                "No license-details.json file found in {} - skipping Python dependency scan",
+                licenseDetailsJsonFile.getPath()
+            );
+            return Collections.emptySet();
+        }
+        return readLicenseDetailsJson(licenseDetailsJsonFile)
+            .stream()
+            .map(d -> mapDependencyToLicense(defaultLicenseMap, d))
+            .peek(d -> d.setInputComponent(context.module()))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<Dependency> readLicenseDetailsJson(File licenseDetailsJsonFile) {
+        final Set<Dependency> dependencySet = new HashSet<>();
+        try (
+            InputStream fis = new FileInputStream(licenseDetailsJsonFile);
+            JsonReader jsonReader = Json.createReader(fis)
+        ) {
+            JsonObject jo = jsonReader.readObject();
+            JsonArray arr = jo.getJsonArray("dependencies");
+            prepareDependencySet(dependencySet, arr);
+            return dependencySet;
+        } catch (Exception e) {
+            LOGGER.error(
+                "Problems reading Python license file {}: {}",
+                licenseDetailsJsonFile.getPath(),
+                e.getMessage()
+            );
+        }
+        return dependencySet;
+    }
+
+    private void prepareDependencySet(Set<Dependency> dependencySet, JsonArray arr) {
+        for (javax.json.JsonValue entry : arr) {
+            JsonObject jsonDepObj = entry.asJsonObject();
+            String moduleLicense = getModuleLicenseFromJsonObject(jsonDepObj);
+            String moduleLicenseUrl = null;
+            if (jsonDepObj.containsKey("moduleUrls")) {
+                JsonArray urls = jsonDepObj.getJsonArray("moduleUrls");
+                if (urls != null && !urls.isEmpty()) {
+                    moduleLicenseUrl = urls.getString(0, null);
+                }
+            }
+            Dependency dep = new Dependency(
+                jsonDepObj.getString("moduleName", null),
+                jsonDepObj.getString("moduleVersion", null),
+                moduleLicense,
+                LicenseCheckRulesDefinition.LANG_PYTHON
+            );
+            dep.setPomPath(moduleLicenseUrl);
+            dependencySet.add(dep);
+        }
+    }
+
+    private String getModuleLicenseFromJsonObject(JsonObject jsonDepObj) {
+        String moduleLicense = null;
+        if (jsonDepObj.containsKey("moduleLicenses")) {
+            JsonArray arrModuleLicenses = jsonDepObj.getJsonArray("moduleLicenses");
+            if (arrModuleLicenses != null && !arrModuleLicenses.isEmpty()) {
+                JsonObject firstJsonObj = arrModuleLicenses.getJsonObject(0);
+                if (firstJsonObj != null) {
+                    moduleLicense = firstJsonObj.getString("moduleLicense", null);
+                    if (moduleLicense == null) {
+                        moduleLicense = firstJsonObj.getString("moduleLicenseUrl", null);
+                    }
+                }
+            }
+        }
+        return moduleLicense;
+    }
+
+    private Dependency mapDependencyToLicense(
+        Map<Pattern, String> defaultLicenseMap,
+        Dependency dependency
+    ) {
+        if (StringUtils.isBlank(dependency.getLicense())) {
+            LOGGER.error("License not found for Dependency {}", dependency);
+            return dependency;
+        }
+        for (Map.Entry<Pattern, String> allowedDependency : defaultLicenseMap.entrySet()) {
+            if (allowedDependency.getKey().matcher(dependency.getLicense()).matches()) {
+                dependency.setLicense(allowedDependency.getValue());
+                break;
+            }
+        }
+        return dependency;
+    }
+}

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinitionTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinitionTest.java
@@ -14,7 +14,7 @@ public class LicenseCheckRulesDefinitionTest {
 
         new LicenseCheckRulesDefinition().define(context);
 
-        assertThat(context.repositories().size(), is(6));
+        assertThat(context.repositories().size(), is(7));
         for (RulesDefinition.Repository repository : context.repositories()) {
             assertThat(repository.rules().size(), is(2));
         }

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinitionTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckRulesDefinitionTest.java
@@ -14,7 +14,7 @@ public class LicenseCheckRulesDefinitionTest {
 
         new LicenseCheckRulesDefinition().define(context);
 
-        assertThat(context.repositories().size(), is(7));
+        assertThat(context.repositories().size(), is(8)); // tăng lên 8 vì thêm dotnet
         for (RulesDefinition.Repository repository : context.repositories()) {
             assertThat(repository.rules().size(), is(2));
         }

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensorTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensorTest.java
@@ -51,7 +51,8 @@ public class LicenseCheckSensorTest {
                 RULE_REPO_KEY_JS,
                 RULE_REPO_KEY_TS,
                 RULE_REPO_KEY_GROOVY,
-                RULE_REPO_KEY_KOTLIN
+                RULE_REPO_KEY_KOTLIN,
+                LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON
             );
     }
 

--- a/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensorTest.java
+++ b/src/test/java/at/porscheinformatik/sonarqube/licensecheck/LicenseCheckSensorTest.java
@@ -52,7 +52,8 @@ public class LicenseCheckSensorTest {
                 RULE_REPO_KEY_TS,
                 RULE_REPO_KEY_GROOVY,
                 RULE_REPO_KEY_KOTLIN,
-                LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON
+                LicenseCheckRulesDefinition.RULE_REPO_KEY_PYTHON,
+                LicenseCheckRulesDefinition.RULE_REPO_KEY_DOTNET
             );
     }
 


### PR DESCRIPTION
This PR adds support for Python and .NET projects to the SonarQube License Check plugin.

Implements PythonDependencyScanner and DotnetDependencyScanner.
Supports license file formats generated by licensecheck (2025.1.0+) (Python) and dotnet-project-licenses (.NET).
Updates documentation and integration guide for new languages.
Adds developer info and AvePoint custom version.
How to use:

For Python: use licensecheck to generate tests/reports/python-licenses.json.
For .NET: use dotnet-project-licenses to generate tests/reports/dotnet-licenses.json.