### PR TITLE
fix: skip artifacts with "data" classifier

### DIFF
--- a/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
+++ b/src/main/java/at/porscheinformatik/sonarqube/licensecheck/maven/MavenDependencyScanner.java
@@ -203,6 +203,10 @@ public class MavenDependencyScanner implements Scanner {
         }
 
         if (classifier != null) {
+            if ("data".equals(classifier)) {
+                // skip data classifier
+                return null;
+            }
             path = path.replace("-" + classifier, "");
         }
         int lastDotIndex = path.lastIndexOf('.');


### PR DESCRIPTION
Some Maven dependencies have an additional artifact with "data" classifiers which leads to the issue that in some cases the license cannot be found correctly.